### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/proof-html.yml
+++ b/.github/workflows/proof-html.yml
@@ -1,4 +1,6 @@
 name: Proof HTML
+permissions:
+  contents: read
 on:
   push:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/Mauritania-Programmers-Community/demo-repository/security/code-scanning/1](https://github.com/Mauritania-Programmers-Community/demo-repository/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to set the minimal privileges necessary for the workflow to function. Since the workflow only needs to fetch and read contents (to run the proof HTML action on them), it should grant only `contents: read` permissions. This should be placed at the top level of the workflow file (after the `name` but before jobs), so that it applies to all jobs in the file—unless a job explicitly overrides it. No further imports or code changes are needed.

The required edit is to insert:

```yaml
permissions:
  contents: read
```

after the `name` and before or after the `on` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
